### PR TITLE
Remove dot to empty lines

### DIFF
--- a/components/CvPreview.vue
+++ b/components/CvPreview.vue
@@ -177,8 +177,12 @@
                 </span>
               </div>
               <ul v-if="job.summaryArr && job.summaryArr.length > 1" class="cv__list">
-                <li v-for="(line, index) in job.summaryArr" :key="index">
-                  {{ line }}
+                <li
+                  v-for="(line, index) in job.summaryArr"
+                  :key="index"
+                  :class="getLineClass(line)"
+                >
+                  {{ line || '\u00A0' }}
                 </li>
               </ul>
               <p v-else class="font-light">
@@ -259,8 +263,12 @@
                 </span>
               </div>
               <ul v-if="project.summaryArr && project.summaryArr.length > 1" class="cv__list">
-                <li v-for="(line, index) in project.summaryArr" :key="index">
-                  {{ line }}
+                <li
+                  v-for="(line, index) in project.summaryArr"
+                  :key="index"
+                  :class="getLineClass(line)"
+                >
+                  {{ line || '\u00A0' }}
                 </li>
               </ul>
               <p v-else class="font-light">
@@ -385,6 +393,15 @@ export default defineComponent({
       }
     });
 
+    const getLineClass = computed(function () {
+      return function (line: any) {
+        return {
+          'with-dot': line.trim().length > 0,
+          'without-dot': line.trim().length === 0,
+        };
+      };
+    });
+
     return {
       formSettings,
       isLoading,
@@ -397,6 +414,7 @@ export default defineComponent({
       cv,
       cvMain,
       pages,
+      getLineClass,
     };
   },
 });
@@ -552,10 +570,13 @@ p {
     li:first-child {
       @apply mt-1;
     }
-    li::before {
+    .with-dot::before {
       content: '\2022';
-      padding-right: 0.4em;
+      padding-right: 0.2em;
       color: var(--primary);
+    }
+    .without-dot::before {
+      content: none;
     }
   }
 


### PR DESCRIPTION
Remove dot to empty lines in preview for Experience and Project description.

Current:
<img width="370" alt="Screenshot 2024-02-20 at 13 57 21" src="https://github.com/claudiabdm/cvfy/assets/11648253/d20c0915-8545-456c-b4b2-bbe4a520ea71">

Fixed:
<img width="373" alt="Screenshot 2024-02-20 at 14 03 24" src="https://github.com/claudiabdm/cvfy/assets/11648253/2ccf9f72-92fa-45e0-a8ae-ffdf7b133629">
