### PR TITLE
Fix date formatting issue by setting time zone to UTC

### DIFF
--- a/composables/useFormatDate.ts
+++ b/composables/useFormatDate.ts
@@ -3,6 +3,7 @@ export default function useFormatDate() {
 
   return function formatDate(date: Date): string {
     const options: Intl.DateTimeFormatOptions = {
+      timeZone: 'UTC',
       year: 'numeric',
       month: 'short',
     }


### PR DESCRIPTION
(closes #59)
# What was done
- Updated the useFormatDate function to include the `timeZone: 'UTC'` option in the `Intl.DateTimeFormatOptions`, this ensures the date is interpreted and displayed in Coordinated Universal Time (UTC), preventing off-by-one-day errors.

# How to test
- Run the project and set the date of an Experience (or Project) field to 01/01/2024 (or day one of any month)
- See the displayed date on CV