### PR TITLE
fix(security): PR Previews from Forks

### DIFF
--- a/.github/workflows/build-preview.yml
+++ b/.github/workflows/build-preview.yml
@@ -1,0 +1,36 @@
+name: Build Preview Deployment
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+# cancel in-progress runs on new commits to same PR (github.event.number)
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.number || github.sha }}
+  cancel-in-progress: true
+
+jobs:
+  build-preview:
+    runs-on: ubuntu-latest
+    name: Build Preview Site and Upload Build Artifact
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20.15.0
+          cache: npm
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Build dist folder
+        run: npm run generate
+
+      # Uploads the build directory as a workflow artifact
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: preview-build
+          path: ./dist

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -1,62 +1,39 @@
-#################### 🚧 WARNING: READ THIS BEFORE USING THIS FILE 🚧 ####################
-#
-#
-#
-# IF YOU DON'T KNOW WHAT YOU'RE DOING, YOU CAN EASILY LEAK SECRETS BY USING A
-# `pull_request_target` WORKFLOW INSTEAD OF `pull_request`! SERIOUSLY, DO NOT
-# BLINDLY COPY AND PASTE THIS FILE WITHOUT UNDERSTANDING THE FULL IMPLICATIONS
-# OF WHAT YOU'RE DOING! WE HAVE TESTED THIS FOR OUR OWN USE CASES, WHICH ARE
-# NOT NECESSARILY THE SAME AS YOURS! WHILE WE AREN'T EXPOSING ANY OF OUR SECRETS,
-# ONE COULD EASILY DO SO BY MODIFYING OR ADDING A STEP TO THIS WORKFLOW!
-#
-#
-#
-#################### 🚧 WARNING: READ THIS BEFORE USING THIS FILE 🚧 ####################
-
-name: Preview Deployment
+name: Upload Preview Deployment
 on:
-  pull_request_target:
+  workflow_run:
+    workflows: [Build Preview Deployment]
+    types:
+      - completed
 
-# cancel in-progress runs on new commits to same PR (github.event.number)
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.number || github.sha }}
-  cancel-in-progress: true
+permissions:
+  actions: read
+  deployments: write
+  contents: read
+  pull-requests: write
 
 jobs:
   deploy-preview:
-      permissions:
-          contents: read
-          pull-requests: write
-          deployments: write
-      runs-on: ubuntu-latest
-      name: Deploy Preview to Cloudflare Pages
-      steps:
-          - name: Checkout
-            uses: actions/checkout@v4
-            with:
-                ref: ${{ github.event.pull_request.head.ref }}
-                repository: ${{ github.event.pull_request.head.repo.full_name }}
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    name: Deploy Preview to Cloudflare Pages
+    steps:
+      # Downloads the build directory from the previous workflow
+      - name: Download build artifact
+        uses: actions/download-artifact@v4
+        id: preview-build-artifact
+        with:
+          name: preview-build
+          path: build
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ github.event.workflow_run.id }}
 
-          - name: Set up Node.js
-            uses: actions/setup-node@v4
-            with:
-              node-version: '20.15.0'
-              cache: npm
-        
-          - name: Install dependencies
-            run: npm install
-        
-          - name: Build dist folder
-            run: npm run generate
-
-          - name: Deploy to Cloudflare Pages
-            id: cloudflare-pages-deploy
-            uses: AdrianGonz97/refined-cf-pages-action@v1
-            with:
-                apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-                accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-                githubToken: ${{ secrets.GITHUB_TOKEN }}
-                projectName: cvfy
-                directory: ./dist
-                deploymentName: Preview
-                wranglerVersion: '3'
+      - name: Deploy to Cloudflare Pages
+        uses: AdrianGonz97/refined-cf-pages-action@v1
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          githubToken: ${{ secrets.GITHUB_TOKEN }}
+          projectName: cvfy
+          deploymentName: Preview
+          wranglerVersion: '3'
+          directory: ${{ steps.preview-build-artifact.outputs.download-path }}


### PR DESCRIPTION
## The Issue

Hey! I'm the maintainer of the Github Action [refined-cf-pages-action](https://github.com/AdrianGonz97/refined-cf-pages-action) and we were recently made aware of a security vulnerability regarding the `pull_request_target` workflow event where it's possible to leak secrets (including the CF credentials used in the action) through a Github Actions exploit when running untrusted code. Unfortunately, our previous recommendation for the setup of the _PR Previews from Forks_ feature included the use of this workflow event type without PR approvals, which [has now been updated](https://github.com/AdrianGonz97/refined-cf-pages-action#enabling-pr-previews-from-forks). 

I'm going around to all of the dependents of the action that are using the _PR Previews from Forks_ feature to apply the fix.

## The Fix

We've come up with an alternate method that is safer to use and will resolve this issue entirely. 

Rather than using `pull_request_target`, which runs in a privileged environment (meaning that repository secrets can be used in it), previews will now be deployed in two stages:

1. The first stage (`build-preview.yml`) will use the `pull_request` event, which runs in an unprivileged environment, making it safe to run untrusted code. The site will be built in this stage and the build directory will be uploaded to Github as an [artifact](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/storing-workflow-data-as-artifacts).
2. The second stage (`deploy-preview.yml`) will use the `workflow_run` event, which runs in a privileged environment where its only job will be to download the build artifact and then run the `refined-cf-pages-action` action to upload the build files to Cloudflare Pages for preview deployment.

---

And that's it! No further actions are necessary. 

Thanks for your time!